### PR TITLE
adding installation requirements to setup.py file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,11 @@ setup(name='flea-pipeline',
         'nose',
         'coverage',
         ],
-      scripts=['flea_pipeline/flea.py'],
+      install_requires=[
+        'biopython >= 1.58',
+        'matplotlib >= 1.2.1',
+        'numpy >= 1.6',
+        'docopt >= 0.6.2'
+        ],
+       scripts=['flea_pipeline/flea.py']
      )


### PR DESCRIPTION
This is more of a suggestion to use setup_requires as opposed to a requirements.txt file. 
